### PR TITLE
Fix for mixed-content warning in https

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
         <link rel="canonical" href="{{ .Site.BaseURL }}" />
         <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .RSSLink }}">
         <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}css/main.css"/>
-        <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:300|Montserrat:700" rel="stylesheet" type="text/css">
+        <link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300|Montserrat:700" rel="stylesheet" type="text/css">
         <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
         <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
     </head>


### PR DESCRIPTION
Request fonts from fonts.googleapis.com using schemaless URL, like the other includes in this file
